### PR TITLE
Update the actions' version

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -16,11 +16,14 @@ jobs:
     steps:
       - name: GitHub App token
         id: github_app_token
-        uses: tibdex/github-app-token@v1.5.0
+        uses: tibdex/github-app-token@v2.1.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
-          installation_id: 22958780
+          # https://github.com/tibdex/github-app-token/releases/tag/v2.0.0
+          # https://github.com/tibdex/github-app-token/compare/v1.5.0...v2.1.0#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R11-R30
+          installation_retrieval_mode: id
+          installation_retrieval_payload: 22958780
 
       - name: Backport
         uses: VachaShah/backport@v2.2.0

--- a/.github/workflows/cypress-e2e-reporting-test.yml
+++ b/.github/workflows/cypress-e2e-reporting-test.yml
@@ -78,15 +78,12 @@ jobs:
         shell: bash
 
       - name: Checkout OpenSearch Dashboards
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: OpenSearch-Dashboards
           repository: opensearch-project/OpenSearch-Dashboards
           ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
           fetch-depth: 0
-          filter: |
-            cypress
-            test
 
       - name: Checkout Dashboards Reporting Plugin in OpenSearch Dashboards Plugins Dir
         uses: actions/checkout@v4

--- a/.github/workflows/cypress-e2e-reporting-test.yml
+++ b/.github/workflows/cypress-e2e-reporting-test.yml
@@ -43,9 +43,9 @@ jobs:
           filename: reports-scheduler.zip
 
       - name: Download OpenSearch
-        uses: peternied/download-file@v3
-        with:
-          url: https://artifacts.opensearch.org/snapshots/core/opensearch/${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/opensearch-min-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT-linux-x64-latest.tar.gz
+        run: |
+          wget 'https://artifacts.opensearch.org/snapshots/core/opensearch/${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/opensearch-min-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT-linux-x64-latest.tar.gz' --retry-connrefused --tries=3 --no-dns-cache --progress=bar:force:noscroll --verbose
+        shell: bash
 
       - name: Extract OpenSearch
         run: |

--- a/.github/workflows/cypress-e2e-reporting-test.yml
+++ b/.github/workflows/cypress-e2e-reporting-test.yml
@@ -79,7 +79,7 @@ jobs:
         shell: bash
 
       - name: Checkout OpenSearch Dashboards
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: OpenSearch-Dashboards
           repository: opensearch-project/OpenSearch-Dashboards
@@ -90,7 +90,7 @@ jobs:
             test
 
       - name: Checkout Dashboards Reporting Plugin in OpenSearch Dashboards Plugins Dir
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
             path: OpenSearch-Dashboards/plugins/${{ env.PLUGIN_NAME }}
 

--- a/.github/workflows/cypress-e2e-reporting-test.yml
+++ b/.github/workflows/cypress-e2e-reporting-test.yml
@@ -43,7 +43,7 @@ jobs:
           filename: reports-scheduler.zip
 
       - name: Download OpenSearch
-        uses: peternied/download-file@v2
+        uses: peternied/download-file@v3
         with:
           url: https://artifacts.opensearch.org/snapshots/core/opensearch/${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/opensearch-min-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT-linux-x64-latest.tar.gz
 

--- a/.github/workflows/cypress-e2e-reporting-test.yml
+++ b/.github/workflows/cypress-e2e-reporting-test.yml
@@ -30,21 +30,21 @@ jobs:
 
       - name: Download Job Scheduler artifact
         run: |
-          if [ ! -f "plugin-artifacts/job-scheduler.zip" ]; then
+          if [ ! -d "plugin-artifacts" ]; then
             mkdir -p plugin-artifacts
             wget -O plugin-artifacts/job-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-job-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
           else
-            echo "File already exists. Skipping download."
+            echo "Folder already exists. Skipping download."
           fi
         shell: bash
 
       - name: Download Reports Scheduler artifact
         run: |
-          if [ ! -f "plugin-artifacts/reports-scheduler.zip" ]; then
+          if [ ! -d "plugin-artifacts" ]; then
             mkdir -p plugin-artifacts
             wget -O plugin-artifacts/reports-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-reports-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
           else
-            echo "File already exists. Skipping download."
+            echo "Folder already exists. Skipping download."
           fi
         shell: bash
 

--- a/.github/workflows/cypress-e2e-reporting-test.yml
+++ b/.github/workflows/cypress-e2e-reporting-test.yml
@@ -101,7 +101,7 @@ jobs:
         working-directory: OpenSearch-Dashboards
         shell: bash
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ steps.tool-versions.outputs.node_version }}
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/cypress-e2e-reporting-test.yml
+++ b/.github/workflows/cypress-e2e-reporting-test.yml
@@ -32,20 +32,16 @@ jobs:
         run: |
           if [ ! -d "plugin-artifacts" ]; then
             mkdir -p plugin-artifacts
-            wget -O plugin-artifacts/job-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-job-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
-          else
-            echo "Folder already exists. Skipping download."
           fi
+          wget -O plugin-artifacts/job-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-job-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
         shell: bash
 
       - name: Download Reports Scheduler artifact
         run: |
           if [ ! -d "plugin-artifacts" ]; then
             mkdir -p plugin-artifacts
-            wget -O plugin-artifacts/reports-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-reports-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
-          else
-            echo "Folder already exists. Skipping download."
           fi
+          wget -O plugin-artifacts/reports-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-reports-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
         shell: bash
 
       - name: Download OpenSearch

--- a/.github/workflows/cypress-e2e-reporting-test.yml
+++ b/.github/workflows/cypress-e2e-reporting-test.yml
@@ -28,14 +28,14 @@ jobs:
           java-version: ${{ matrix.jdk }}
 
       - name: Download Job Scheduler artifact
-        uses: suisei-cn/actions-download-file@v1.4.0
+        uses: suisei-cn/actions-download-file@v1.6.0
         with:
           url: https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-job-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip
           target: plugin-artifacts/
           filename: job-scheduler.zip
 
       - name: Download Reports Scheduler artifact
-        uses: suisei-cn/actions-download-file@v1.4.0
+        uses: suisei-cn/actions-download-file@v1.6.0
         with:
           url: https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-reports-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip
           target: plugin-artifacts/

--- a/.github/workflows/cypress-e2e-reporting-test.yml
+++ b/.github/workflows/cypress-e2e-reporting-test.yml
@@ -30,17 +30,13 @@ jobs:
 
       - name: Download Job Scheduler artifact
         run: |
-          if [ ! -d "plugin-artifacts" ]; then
-            mkdir -p plugin-artifacts
-          fi
+          mkdir -p plugin-artifacts
           wget -O plugin-artifacts/job-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-job-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
         shell: bash
 
       - name: Download Reports Scheduler artifact
         run: |
-          if [ ! -d "plugin-artifacts" ]; then
-            mkdir -p plugin-artifacts
-          fi
+          mkdir -p plugin-artifacts
           wget -O plugin-artifacts/reports-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-reports-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
         shell: bash
 

--- a/.github/workflows/cypress-e2e-reporting-test.yml
+++ b/.github/workflows/cypress-e2e-reporting-test.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.jdk }}
 

--- a/.github/workflows/cypress-e2e-reporting-test.yml
+++ b/.github/workflows/cypress-e2e-reporting-test.yml
@@ -79,18 +79,18 @@ jobs:
         shell: bash
 
       - name: Checkout OpenSearch Dashboards
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: OpenSearch-Dashboards
           repository: opensearch-project/OpenSearch-Dashboards
           ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
           fetch-depth: 0
-          filter: |
+          sparse-checkout: |
             cypress
             test
 
       - name: Checkout Dashboards Reporting Plugin in OpenSearch Dashboards Plugins Dir
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
             path: OpenSearch-Dashboards/plugins/${{ env.PLUGIN_NAME }}
 

--- a/.github/workflows/cypress-e2e-reporting-test.yml
+++ b/.github/workflows/cypress-e2e-reporting-test.yml
@@ -30,12 +30,22 @@ jobs:
 
       - name: Download Job Scheduler artifact
         run: |
-          wget -O plugin-artifacts/job-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-job-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
+          if [ ! -f "plugin-artifacts/job-scheduler.zip" ]; then
+            mkdir -p plugin-artifacts
+            wget -O plugin-artifacts/job-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-job-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
+          else
+            echo "File already exists. Skipping download."
+          fi
         shell: bash
 
       - name: Download Reports Scheduler artifact
         run: |
-          wget -O plugin-artifacts/reports-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-reports-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
+          if [ ! -f "plugin-artifacts/reports-scheduler.zip" ]; then
+            mkdir -p plugin-artifacts
+            wget -O plugin-artifacts/reports-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-reports-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
+          else
+            echo "File already exists. Skipping download."
+          fi
         shell: bash
 
       - name: Download OpenSearch

--- a/.github/workflows/cypress-e2e-reporting-test.yml
+++ b/.github/workflows/cypress-e2e-reporting-test.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.jdk }}
 
       - name: Download Job Scheduler artifact

--- a/.github/workflows/cypress-e2e-reporting-test.yml
+++ b/.github/workflows/cypress-e2e-reporting-test.yml
@@ -79,7 +79,7 @@ jobs:
         shell: bash
 
       - name: Checkout OpenSearch Dashboards
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           path: OpenSearch-Dashboards
           repository: opensearch-project/OpenSearch-Dashboards
@@ -90,7 +90,7 @@ jobs:
             test
 
       - name: Checkout Dashboards Reporting Plugin in OpenSearch Dashboards Plugins Dir
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
             path: OpenSearch-Dashboards/plugins/${{ env.PLUGIN_NAME }}
 

--- a/.github/workflows/cypress-e2e-reporting-test.yml
+++ b/.github/workflows/cypress-e2e-reporting-test.yml
@@ -79,13 +79,13 @@ jobs:
         shell: bash
 
       - name: Checkout OpenSearch Dashboards
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           path: OpenSearch-Dashboards
           repository: opensearch-project/OpenSearch-Dashboards
           ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
           fetch-depth: 0
-          sparse-checkout: |
+          filter: |
             cypress
             test
 

--- a/.github/workflows/cypress-e2e-reporting-test.yml
+++ b/.github/workflows/cypress-e2e-reporting-test.yml
@@ -29,18 +29,14 @@ jobs:
           java-version: ${{ matrix.jdk }}
 
       - name: Download Job Scheduler artifact
-        uses: suisei-cn/actions-download-file@v1.6.0
-        with:
-          url: https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-job-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip
-          target: plugin-artifacts/
-          filename: job-scheduler.zip
+        run: |
+          wget -O plugin-artifacts/job-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-job-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
+        shell: bash
 
       - name: Download Reports Scheduler artifact
-        uses: suisei-cn/actions-download-file@v1.6.0
-        with:
-          url: https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-reports-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip
-          target: plugin-artifacts/
-          filename: reports-scheduler.zip
+        run: |
+          wget -O plugin-artifacts/reports-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-reports-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
+        shell: bash
 
       - name: Download OpenSearch
         run: |

--- a/.github/workflows/dashboards-reports-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-reports-test-and-build-workflow.yml
@@ -51,7 +51,7 @@ jobs:
                                  whoami && yarn osd bootstrap --single-version=loose && yarn test --coverage"
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4.6.0
+        uses: codecov/codecov-action@v3
         with:
           flags: dashboards-report
           directory: ./OpenSearch-Dashboards/plugins/

--- a/.github/workflows/dashboards-reports-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-reports-test-and-build-workflow.yml
@@ -39,7 +39,7 @@ jobs:
           path: OpenSearch-Dashboards/plugins/${{ env.PLUGIN_NAME }}
 
       - name: OpenSearch Dashboards Plugin Bootstrap and test
-        uses: nick-fields/retry@v1
+        uses: nick-fields/retry@v2.9.0
         with:
           timeout_minutes: 30
           max_attempts: 3
@@ -110,14 +110,14 @@ jobs:
   #         path: OpenSearch-Dashboards/plugins/${{ env.PLUGIN_NAME }}
 
   #     - name: OpenSearch Dashboards Plugin Bootstrap
-  #       uses: nick-fields/retry@v1
+  #       uses: nick-fields/retry@@v2.9.0
   #       with:
   #         timeout_minutes: 30
   #         max_attempts: 3
   #         command: yarn osd bootstrap --single-version=loose
 
   #     - name: Test
-  #       uses: nick-fields/retry@v1
+  #       uses: nick-fields/retry@@v2.9.0
   #       with:
   #         timeout_minutes: 30
   #         max_attempts: 3
@@ -167,14 +167,14 @@ jobs:
   #         path: OpenSearch-Dashboards/plugins/${{ env.PLUGIN_NAME }}
 
   #     - name: OpenSearch Dashboards Plugin Bootstrap
-  #       uses: nick-fields/retry@v1
+  #       uses: nick-fields/retry@@v2.9.0
   #       with:
   #         timeout_minutes: 30
   #         max_attempts: 3
   #         command: yarn osd bootstrap --single-version=loose
 
   #     - name: Test
-  #       uses: nick-fields/retry@v1
+  #       uses: nick-fields/retry@@v2.9.0
   #       with:
   #         timeout_minutes: 30
   #         max_attempts: 3

--- a/.github/workflows/dashboards-reports-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-reports-test-and-build-workflow.yml
@@ -88,7 +88,7 @@ jobs:
   #         path: OpenSearch-Dashboards
 
   #     - name: Setup Node
-  #       uses: actions/setup-node@v3
+  #       uses: actions/setup-node@v4
   #       with:
   #         node-version-file: '../OpenSearch-Dashboards/.nvmrc'
   #         registry-url: 'https://registry.npmjs.org'
@@ -145,7 +145,7 @@ jobs:
   #         path: OpenSearch-Dashboards
 
   #     - name: Setup Node
-  #       uses: actions/setup-node@v3
+  #       uses: actions/setup-node@v4
   #       with:
   #         node-version-file: '../OpenSearch-Dashboards/.nvmrc'
   #         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/dashboards-reports-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-reports-test-and-build-workflow.yml
@@ -27,14 +27,14 @@ jobs:
 
     steps:
       - name: Checkout OpenSearch Dashboards
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: opensearch-project/Opensearch-Dashboards
           ref: ${{ env.OPENSEARCH_VERSION }}
           path: OpenSearch-Dashboards
 
       - name: Checkout Plugin	
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:	
           path: OpenSearch-Dashboards/plugins/${{ env.PLUGIN_NAME }}
 
@@ -81,7 +81,7 @@ jobs:
   #       run: git config --system core.longpaths true
 
   #     - name: Checkout OpenSearch Dashboards
-  #       uses: actions/checkout@v1
+  #       uses: actions/checkout@v4
   #       with:
   #         repository: opensearch-project/Opensearch-Dashboards
   #         ref: ${{ env.OPENSEARCH_VERSION }}
@@ -105,7 +105,7 @@ jobs:
   #     - run: yarn -v
 
   #     - name: Checkout Plugin	
-  #       uses: actions/checkout@v1
+  #       uses: actions/checkout@v4
   #       with:	
   #         path: OpenSearch-Dashboards/plugins/${{ env.PLUGIN_NAME }}
 
@@ -138,7 +138,7 @@ jobs:
   #   runs-on: macos-latest
   #   steps:
   #     - name: Checkout OpenSearch Dashboards
-  #       uses: actions/checkout@v1
+  #       uses: actions/checkout@v4
   #       with:
   #         repository: opensearch-project/Opensearch-Dashboards
   #         ref: ${{ env.OPENSEARCH_VERSION }}
@@ -162,7 +162,7 @@ jobs:
   #     - run: yarn -v
 
   #     - name: Checkout Plugin	
-  #       uses: actions/checkout@v1
+  #       uses: actions/checkout@v4
   #       with:	
   #         path: OpenSearch-Dashboards/plugins/${{ env.PLUGIN_NAME }}
 

--- a/.github/workflows/dashboards-reports-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-reports-test-and-build-workflow.yml
@@ -110,14 +110,14 @@ jobs:
   #         path: OpenSearch-Dashboards/plugins/${{ env.PLUGIN_NAME }}
 
   #     - name: OpenSearch Dashboards Plugin Bootstrap
-  #       uses: nick-fields/retry@@v2.9.0
+  #       uses: nick-fields/retry@v2.9.0
   #       with:
   #         timeout_minutes: 30
   #         max_attempts: 3
   #         command: yarn osd bootstrap --single-version=loose
 
   #     - name: Test
-  #       uses: nick-fields/retry@@v2.9.0
+  #       uses: nick-fields/retry@v2.9.0
   #       with:
   #         timeout_minutes: 30
   #         max_attempts: 3
@@ -167,14 +167,14 @@ jobs:
   #         path: OpenSearch-Dashboards/plugins/${{ env.PLUGIN_NAME }}
 
   #     - name: OpenSearch Dashboards Plugin Bootstrap
-  #       uses: nick-fields/retry@@v2.9.0
+  #       uses: nick-fields/retry@v2.9.0
   #       with:
   #         timeout_minutes: 30
   #         max_attempts: 3
   #         command: yarn osd bootstrap --single-version=loose
 
   #     - name: Test
-  #       uses: nick-fields/retry@@v2.9.0
+  #       uses: nick-fields/retry@v2.9.0
   #       with:
   #         timeout_minutes: 30
   #         max_attempts: 3

--- a/.github/workflows/dashboards-reports-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-reports-test-and-build-workflow.yml
@@ -51,7 +51,7 @@ jobs:
                                  whoami && yarn osd bootstrap --single-version=loose && yarn test --coverage"
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4.6.0
         with:
           flags: dashboards-report
           directory: ./OpenSearch-Dashboards/plugins/

--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Step 01 - Download the plugin's source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: wazuh/wazuh-dashboards-reporting
           ref: ${{ inputs.reference }}

--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -82,10 +82,11 @@ jobs:
 
       - name: Step 04 - Upload artifact to GitHub
         if: ${{ inputs.artifact_name && inputs.artifact_path }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
           path: ${{ inputs.artifact_path }}
+          overwrite: true
 
       - name: Step 05 - Upload coverage results to GitHub
         if: ${{ inputs.notify_jest_coverage_summary && github.event_name == 'pull_request' }}

--- a/.github/workflows/draft-release-notes-workflow.yml
+++ b/.github/workflows/draft-release-notes-workflow.yml
@@ -12,7 +12,8 @@ jobs:
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - name: Update draft release notes
-        uses: release-drafter/release-drafter@v5
+        # https://github.com/release-drafter/release-drafter/compare/v5.25.0...v6.0.0
+        uses: release-drafter/release-drafter@v6
         with:
           config-name: draft-release-notes-config.yml
           tag: (None)

--- a/.github/workflows/ftr-e2e-reporting-test.yml
+++ b/.github/workflows/ftr-e2e-reporting-test.yml
@@ -78,15 +78,12 @@ jobs:
         shell: bash
 
       - name: Checkout OpenSearch Dashboards
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: OpenSearch-Dashboards
           repository: opensearch-project/OpenSearch-Dashboards
           ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
           fetch-depth: 0
-          filter: |
-            cypress
-            test
 
       - name: Checkout Dashboards Reporting Plugin in OpenSearch Dashboards Plugins Dir
         uses: actions/checkout@v4

--- a/.github/workflows/ftr-e2e-reporting-test.yml
+++ b/.github/workflows/ftr-e2e-reporting-test.yml
@@ -43,9 +43,9 @@ jobs:
           filename: reports-scheduler.zip
 
       - name: Download OpenSearch
-        uses: peternied/download-file@v3
-        with:
-          url: https://artifacts.opensearch.org/snapshots/core/opensearch/${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/opensearch-min-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT-linux-x64-latest.tar.gz
+        run: |
+          wget 'https://artifacts.opensearch.org/snapshots/core/opensearch/${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/opensearch-min-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT-linux-x64-latest.tar.gz' --retry-connrefused --tries=3 --no-dns-cache --progress=bar:force:noscroll --verbose
+        shell: bash
 
       - name: Extract OpenSearch
         run: |

--- a/.github/workflows/ftr-e2e-reporting-test.yml
+++ b/.github/workflows/ftr-e2e-reporting-test.yml
@@ -43,7 +43,7 @@ jobs:
           filename: reports-scheduler.zip
 
       - name: Download OpenSearch
-        uses: peternied/download-file@v2
+        uses: peternied/download-file@v3
         with:
           url: https://artifacts.opensearch.org/snapshots/core/opensearch/${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/opensearch-min-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT-linux-x64-latest.tar.gz
 

--- a/.github/workflows/ftr-e2e-reporting-test.yml
+++ b/.github/workflows/ftr-e2e-reporting-test.yml
@@ -30,21 +30,21 @@ jobs:
 
       - name: Download Job Scheduler artifact
         run: |
-          if [ ! -f "plugin-artifacts/job-scheduler.zip" ]; then
+          if [ ! -d "plugin-artifacts" ]; then
             mkdir -p plugin-artifacts
             wget -O plugin-artifacts/job-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-job-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
           else
-            echo "File already exists. Skipping download."
+            echo "Folder already exists. Skipping download."
           fi
         shell: bash
 
       - name: Download Reports Scheduler artifact
         run: |
-          if [ ! -f "plugin-artifacts/reports-scheduler.zip" ]; then
+          if [ ! -d "plugin-artifacts" ]; then
             mkdir -p plugin-artifacts
             wget -O plugin-artifacts/reports-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-reports-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
           else
-            echo "File already exists. Skipping download."
+            echo "Folder already exists. Skipping download."
           fi
         shell: bash
 

--- a/.github/workflows/ftr-e2e-reporting-test.yml
+++ b/.github/workflows/ftr-e2e-reporting-test.yml
@@ -101,7 +101,7 @@ jobs:
         working-directory: OpenSearch-Dashboards
         shell: bash
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ steps.tool-versions.outputs.node_version }}
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/ftr-e2e-reporting-test.yml
+++ b/.github/workflows/ftr-e2e-reporting-test.yml
@@ -32,20 +32,16 @@ jobs:
         run: |
           if [ ! -d "plugin-artifacts" ]; then
             mkdir -p plugin-artifacts
-            wget -O plugin-artifacts/job-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-job-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
-          else
-            echo "Folder already exists. Skipping download."
           fi
+          wget -O plugin-artifacts/job-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-job-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
         shell: bash
 
       - name: Download Reports Scheduler artifact
         run: |
           if [ ! -d "plugin-artifacts" ]; then
             mkdir -p plugin-artifacts
-            wget -O plugin-artifacts/reports-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-reports-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
-          else
-            echo "Folder already exists. Skipping download."
           fi
+          wget -O plugin-artifacts/reports-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-reports-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
         shell: bash
 
       - name: Download OpenSearch

--- a/.github/workflows/ftr-e2e-reporting-test.yml
+++ b/.github/workflows/ftr-e2e-reporting-test.yml
@@ -28,14 +28,14 @@ jobs:
           java-version: ${{ matrix.jdk }}
 
       - name: Download Job Scheduler artifact
-        uses: suisei-cn/actions-download-file@v1.4.0
+        uses: suisei-cn/actions-download-file@v1.6.0
         with:
           url: https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-job-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip
           target: plugin-artifacts/
           filename: job-scheduler.zip
 
       - name: Download Reports Scheduler artifact
-        uses: suisei-cn/actions-download-file@v1.4.0
+        uses: suisei-cn/actions-download-file@v1.6.0
         with:
           url: https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-reports-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip
           target: plugin-artifacts/

--- a/.github/workflows/ftr-e2e-reporting-test.yml
+++ b/.github/workflows/ftr-e2e-reporting-test.yml
@@ -30,17 +30,13 @@ jobs:
 
       - name: Download Job Scheduler artifact
         run: |
-          if [ ! -d "plugin-artifacts" ]; then
-            mkdir -p plugin-artifacts
-          fi
+          mkdir -p plugin-artifacts
           wget -O plugin-artifacts/job-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-job-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
         shell: bash
 
       - name: Download Reports Scheduler artifact
         run: |
-          if [ ! -d "plugin-artifacts" ]; then
-            mkdir -p plugin-artifacts
-          fi
+          mkdir -p plugin-artifacts
           wget -O plugin-artifacts/reports-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-reports-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
         shell: bash
 

--- a/.github/workflows/ftr-e2e-reporting-test.yml
+++ b/.github/workflows/ftr-e2e-reporting-test.yml
@@ -79,7 +79,7 @@ jobs:
         shell: bash
 
       - name: Checkout OpenSearch Dashboards
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: OpenSearch-Dashboards
           repository: opensearch-project/OpenSearch-Dashboards
@@ -90,7 +90,7 @@ jobs:
             test
 
       - name: Checkout Dashboards Reporting Plugin in OpenSearch Dashboards Plugins Dir
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
             path: OpenSearch-Dashboards/plugins/${{ env.PLUGIN_NAME }}
 
@@ -137,7 +137,7 @@ jobs:
         working-directory: OpenSearch-Dashboards
 
       - name: Checkout Dashboards Functioanl Test Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: opensearch-dashboards-functional-test
           repository: opensearch-project/opensearch-dashboards-functional-test

--- a/.github/workflows/ftr-e2e-reporting-test.yml
+++ b/.github/workflows/ftr-e2e-reporting-test.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.jdk }}
 

--- a/.github/workflows/ftr-e2e-reporting-test.yml
+++ b/.github/workflows/ftr-e2e-reporting-test.yml
@@ -79,18 +79,18 @@ jobs:
         shell: bash
 
       - name: Checkout OpenSearch Dashboards
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: OpenSearch-Dashboards
           repository: opensearch-project/OpenSearch-Dashboards
           ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
           fetch-depth: 0
-          filter: |
+          sparse-checkout: |
             cypress
             test
 
       - name: Checkout Dashboards Reporting Plugin in OpenSearch Dashboards Plugins Dir
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
             path: OpenSearch-Dashboards/plugins/${{ env.PLUGIN_NAME }}
 
@@ -137,7 +137,7 @@ jobs:
         working-directory: OpenSearch-Dashboards
 
       - name: Checkout Dashboards Functioanl Test Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: opensearch-dashboards-functional-test
           repository: opensearch-project/opensearch-dashboards-functional-test

--- a/.github/workflows/ftr-e2e-reporting-test.yml
+++ b/.github/workflows/ftr-e2e-reporting-test.yml
@@ -30,12 +30,22 @@ jobs:
 
       - name: Download Job Scheduler artifact
         run: |
-          wget -O plugin-artifacts/job-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-job-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
+          if [ ! -f "plugin-artifacts/job-scheduler.zip" ]; then
+            mkdir -p plugin-artifacts
+            wget -O plugin-artifacts/job-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-job-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
+          else
+            echo "File already exists. Skipping download."
+          fi
         shell: bash
 
       - name: Download Reports Scheduler artifact
         run: |
-          wget -O plugin-artifacts/reports-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-reports-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
+          if [ ! -f "plugin-artifacts/reports-scheduler.zip" ]; then
+            mkdir -p plugin-artifacts
+            wget -O plugin-artifacts/reports-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-reports-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
+          else
+            echo "File already exists. Skipping download."
+          fi
         shell: bash
 
       - name: Download OpenSearch

--- a/.github/workflows/ftr-e2e-reporting-test.yml
+++ b/.github/workflows/ftr-e2e-reporting-test.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.jdk }}
 
       - name: Download Job Scheduler artifact

--- a/.github/workflows/ftr-e2e-reporting-test.yml
+++ b/.github/workflows/ftr-e2e-reporting-test.yml
@@ -79,7 +79,7 @@ jobs:
         shell: bash
 
       - name: Checkout OpenSearch Dashboards
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           path: OpenSearch-Dashboards
           repository: opensearch-project/OpenSearch-Dashboards
@@ -90,7 +90,7 @@ jobs:
             test
 
       - name: Checkout Dashboards Reporting Plugin in OpenSearch Dashboards Plugins Dir
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
             path: OpenSearch-Dashboards/plugins/${{ env.PLUGIN_NAME }}
 
@@ -137,7 +137,7 @@ jobs:
         working-directory: OpenSearch-Dashboards
 
       - name: Checkout Dashboards Functioanl Test Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           path: opensearch-dashboards-functional-test
           repository: opensearch-project/opensearch-dashboards-functional-test

--- a/.github/workflows/ftr-e2e-reporting-test.yml
+++ b/.github/workflows/ftr-e2e-reporting-test.yml
@@ -79,13 +79,13 @@ jobs:
         shell: bash
 
       - name: Checkout OpenSearch Dashboards
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           path: OpenSearch-Dashboards
           repository: opensearch-project/OpenSearch-Dashboards
           ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
           fetch-depth: 0
-          sparse-checkout: |
+          filter: |
             cypress
             test
 

--- a/.github/workflows/ftr-e2e-reporting-test.yml
+++ b/.github/workflows/ftr-e2e-reporting-test.yml
@@ -29,18 +29,14 @@ jobs:
           java-version: ${{ matrix.jdk }}
 
       - name: Download Job Scheduler artifact
-        uses: suisei-cn/actions-download-file@v1.6.0
-        with:
-          url: https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-job-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip
-          target: plugin-artifacts/
-          filename: job-scheduler.zip
+        run: |
+          wget -O plugin-artifacts/job-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-job-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
+        shell: bash
 
       - name: Download Reports Scheduler artifact
-        uses: suisei-cn/actions-download-file@v1.6.0
-        with:
-          url: https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-reports-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip
-          target: plugin-artifacts/
-          filename: reports-scheduler.zip
+        run: |
+          wget -O plugin-artifacts/reports-scheduler.zip "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-reports-scheduler&v=${{ env.OPENSEARCH_PLUGIN_VERSION }}-SNAPSHOT&p=zip"
+        shell: bash
 
       - name: Download OpenSearch
         run: |

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: lychee Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,14 +13,14 @@ jobs:
 
     steps:
       - name: Checkout OpenSearch Dashboards
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: opensearch-project/Opensearch-Dashboards
           ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
           path: OpenSearch-Dashboards
 
       - name: Checkout dashboards reporting
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: OpenSearch-Dashboards/plugins/${{ env.PLUGIN_NAME }}
           fetch-depth: 0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
           echo "::set-output name=yarn_version::$(node -p "(require('./OpenSearch-Dashboards/package.json').engines.yarn).match(/[.0-9]+/)[0]")"
 
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ steps.versions_step.outputs.node_version }}
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:  
       - name: Checkout Branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set env
         run: |

--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run Dashboard
         id: setup-dashboards
-        uses: derek-ho/setup-opensearch-dashboards@v2
+        uses: derek-ho/setup-opensearch-dashboards@v3
         with:
           plugin_name: dashboards-reporting
           built_plugin_name: reportsDashboards

--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -29,7 +29,7 @@ jobs:
         shell: bash
 
       - name: Run Opensearch
-        uses: derek-ho/start-opensearch@v2
+        uses: derek-ho/start-opensearch@v6
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           security-enabled: false


### PR DESCRIPTION
### Description
Several warnings are generated when executing GitHub Workflows, primarily due to the utilization of deprecated versions of GitHub Actions. Upgrading to the latest version resolves these warnings and is a straightforward process.

- https://github.com/wazuh/wazuh-dashboard/actions/runs/11011659384
- https://github.com/wazuh/wazuh-dashboard/actions/runs/11177257996

### Issues Resolved

Closes https://github.com/wazuh/wazuh-dashboard/issues/345

### Evidence

#### Here is why I removed the filter option.

![image](https://github.com/user-attachments/assets/44ca65fe-aa2e-49ee-b2d9-fd61171d531a)

https://github.com/wazuh/wazuh-dashboards-reporting/pull/6/commits/5ff69e45b00e67d883b124ace61d06bf8bbb2a51#diff-f258144e908ac90eebcd80eeb5191a1007b50b9c0ca74325497c2e8d4e666f99L87-L89

https://github.com/wazuh/wazuh-dashboards-reporting/commit/5ff69e45b00e67d883b124ace61d06bf8bbb2a51#diff-ce491377e1248da0574b2312a9960bc2bc35a6e828452954b56176e1347354edL87-L89

## Changelog
- chore: update the actions' version accordingly.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
