### PR TITLE
Update GitHub actions to use Ubuntu 24.04

### DIFF
--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -44,7 +44,7 @@ jobs:
   # using a pre-built Docker image, hosted in Quay.io.
   deploy_and_run_command:
     name: Deploy and run command
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Step 01 - Download the plugin's source code
         uses: actions/checkout@v4


### PR DESCRIPTION
### Description
This pull request updates the GitHub actions use of `ubuntu-latest` to `ubuntu-24.04` to prevent unexpected changes in the image used.

### Issues Resolved
- https://github.com/wazuh/wazuh-dashboard/issues/535

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff
