### PR TITLE
Fix the settings for sending the report by email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fixed invalid date error in report details [#53](https://github.com/wazuh/wazuh-dashboard-reporting/pull/53)
+- Fixed the validation of the notification plugin [#105](https://github.com/wazuh/wazuh-dashboard-reporting/pull/105) 
 
 ### Removed
 

--- a/public/components/report_definitions/delivery/delivery.tsx
+++ b/public/components/report_definitions/delivery/delivery.tsx
@@ -170,7 +170,7 @@ export function ReportDelivery(props: ReportDeliveryProps) {
         return response.text();
       })
       .then(function (data) {
-        if (data.includes('opensearch-notifications')) {
+        if (data.includes('wazuh-indexer-notifications')) {
           setIsHidden(false);
           return;
         }


### PR DESCRIPTION
### Description

The validation has been changed to display the option to send an email; previously, it checked whether the `opensearch-notifications` plugin existed, but now it checks for `wazuh-indexer-notifications`.

### Issues Resolved

- #104 

### Test 

Create a report with a scheduled email delivery and ensure the email is sent