### PR TITLE
Fix error in reporting when downloading a save search from discover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fixed invalid date error in report details [#53](https://github.com/wazuh/wazuh-dashboard-reporting/pull/53)
-- Fixed the validation of the notification plugin [#105](https://github.com/wazuh/wazuh-dashboard-reporting/pull/105) 
+- Fixed the validation of the notification plugin [#105](https://github.com/wazuh/wazuh-dashboard-reporting/pull/105)
+- Fixed request error when generating report for save search on discover [#159](https://github.com/wazuh/wazuh-dashboard-reporting/pull/159)
 
 ### Removed
 

--- a/public/components/context_menu/context_menu.js
+++ b/public/components/context_menu/context_menu.js
@@ -205,7 +205,9 @@ $(function () {
     const timeRanges = getTimeFieldsFromUrl();
     const queryUrl = replaceQueryURL(location.href);
     const savedSearchId = getUuidFromUrl()[1];
-    generateInContextReport(timeRanges, queryUrl, 'csv', { savedSearchId });
+    generateInContextReport(timeRanges, queryUrl, 'csv', {
+      saved_search_id: savedSearchId,
+    });
   });
 
   // generate XLSX onclick
@@ -213,7 +215,9 @@ $(function () {
     const timeRanges = getTimeFieldsFromUrl();
     const queryUrl = replaceQueryURL(location.href);
     const savedSearchId = getUuidFromUrl()[1];
-    generateInContextReport(timeRanges, queryUrl, 'xlsx', { savedSearchId });
+    generateInContextReport(timeRanges, queryUrl, 'xlsx', {
+      saved_search_id: savedSearchId,
+    });
   });
 
   // navigate to Create report definition page with report source and pre-set time range
@@ -293,8 +297,7 @@ const checkURLParams = async () => {
 const isDiscoverNavMenu = () =>
   /\/app\/(discover|data-explorer)/.test(window.location.href);
 
-const isDashboardNavMenu = () =>
-  /\/app\/dashboards/.test(window.location.href);
+const isDashboardNavMenu = () => /\/app\/dashboards/.test(window.location.href);
 
 const isVisualizationNavMenu = () =>
   /\/app\/visualize/.test(window.location.href);
@@ -307,9 +310,7 @@ function locationHashChanged() {
     if (
       navMenu &&
       navMenu.length &&
-      (isDiscoverNavMenu() ||
-        isDashboardNavMenu() ||
-        isVisualizationNavMenu())
+      (isDiscoverNavMenu() || isDashboardNavMenu() || isVisualizationNavMenu())
     ) {
       try {
         if ($('#downloadReport').length) {

--- a/public/components/context_menu/context_menu.js
+++ b/public/components/context_menu/context_menu.js
@@ -164,6 +164,7 @@ const getUuidFromUrl = () => {
   href = href.replace(/[?&]security_tenant=[^&#]*/g, '');
   return href.match(/([0-9a-zA-Z-]+)\?/);
 };
+
 const isDiscover = () => window.location.href.includes('discover');
 
 // open Download drop-down
@@ -205,6 +206,7 @@ $(function () {
     const timeRanges = getTimeFieldsFromUrl();
     const queryUrl = replaceQueryURL(location.href);
     const savedSearchId = getUuidFromUrl()[1];
+    // Wazuh: Rename savedSearchId to saved_search_id to align with the request schema
     generateInContextReport(timeRanges, queryUrl, 'csv', {
       saved_search_id: savedSearchId,
     });
@@ -215,6 +217,7 @@ $(function () {
     const timeRanges = getTimeFieldsFromUrl();
     const queryUrl = replaceQueryURL(location.href);
     const savedSearchId = getUuidFromUrl()[1];
+    // Wazuh: Rename savedSearchId to saved_search_id to align with the request schema
     generateInContextReport(timeRanges, queryUrl, 'xlsx', {
       saved_search_id: savedSearchId,
     });
@@ -297,7 +300,8 @@ const checkURLParams = async () => {
 const isDiscoverNavMenu = () =>
   /\/app\/(discover|data-explorer)/.test(window.location.href);
 
-const isDashboardNavMenu = () => /\/app\/dashboards/.test(window.location.href);
+const isDashboardNavMenu = () =>
+  /\/app\/dashboards/.test(window.location.href);
 
 const isVisualizationNavMenu = () =>
   /\/app\/visualize/.test(window.location.href);
@@ -310,7 +314,9 @@ function locationHashChanged() {
     if (
       navMenu &&
       navMenu.length &&
-      (isDiscoverNavMenu() || isDashboardNavMenu() || isVisualizationNavMenu())
+      (isDiscoverNavMenu() ||
+        isDashboardNavMenu() ||
+        isVisualizationNavMenu())
     ) {
       try {
         if ($('#downloadReport').length) {

--- a/public/components/context_menu/context_menu.js
+++ b/public/components/context_menu/context_menu.js
@@ -267,6 +267,7 @@ $(function () {
     });
   });
 
+  // eslint-disable-next-line no-use-before-define
   checkURLParams();
   locationHashChanged();
 });
@@ -299,8 +300,7 @@ const checkURLParams = async () => {
 const isDiscoverNavMenu = () =>
   /\/app\/(discover|data-explorer)/.test(window.location.href);
 
-const isDashboardNavMenu = () =>
-  /\/app\/dashboards/.test(window.location.href);
+const isDashboardNavMenu = () => /\/app\/dashboards/.test(window.location.href);
 
 const isVisualizationNavMenu = () =>
   /\/app\/visualize/.test(window.location.href);
@@ -313,9 +313,7 @@ function locationHashChanged() {
     if (
       navMenu &&
       navMenu.length &&
-      (isDiscoverNavMenu() ||
-        isDashboardNavMenu() ||
-        isVisualizationNavMenu())
+      (isDiscoverNavMenu() || isDashboardNavMenu() || isVisualizationNavMenu())
     ) {
       try {
         if ($('#downloadReport').length) {

--- a/public/components/context_menu/context_menu.js
+++ b/public/components/context_menu/context_menu.js
@@ -164,7 +164,6 @@ const getUuidFromUrl = () => {
   href = href.replace(/[?&]security_tenant=[^&#]*/g, '');
   return href.match(/([0-9a-zA-Z-]+)\?/);
 };
-
 const isDiscover = () => window.location.href.includes('discover');
 
 // open Download drop-down


### PR DESCRIPTION
### Description
Renames a variable to fix an error that appeared when trying to download a save search from discover, the API expected a variable in snake_case and dashboard was sending it in camelCase.

### Issues Resolved
#158 

### Evidence

https://github.com/user-attachments/assets/9ddcc007-16ac-41fe-847c-e54fad2aa254

### Tests
- Navigate to discover and select an index pattern with data (optional: select a filter or do a search with results).
- Save the search with button `Save`
- Click on `Reporting` and `Generate CSV` and `Generate XLSX` 

### Check List
- [X] Changelog
- [x] Commits are signed per the DCO using --signoff