### PR TITLE
Custom filter buttons are not correctly rendered in the PDF reports 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Fixed invalid date error in report details [#53](https://github.com/wazuh/wazuh-dashboard-reporting/pull/53)
 - Fixed the validation of the notification plugin [#105](https://github.com/wazuh/wazuh-dashboard-reporting/pull/105) 
+- Fixed custom filter buttons not being rendered in pdf reports [#160](https://github.com/wazuh/wazuh-dashboard-reporting/pull/160)
 
 ### Removed
 

--- a/public/components/visual_report/generate_report.ts
+++ b/public/components/visual_report/generate_report.ts
@@ -58,13 +58,17 @@ const removeNonReportElements = (
   reportSource: VISUAL_REPORT_TYPE
 ) => {
   // remove buttons
-  // WAZUH: add :not(.euiButtonGroupButton) to preserve custom button group filters
   doc
     .querySelectorAll(
-      "button[class^='euiButton']:not(.visLegend__button):not(.euiButtonGroupButton)"
+      "button[class^='euiButton']:not(.visLegend__button)"
     )
-    .forEach((e) => e.remove());
-  // END WAZUH
+    .forEach((e) => {
+      // WAZUH: preserve elements marked with keep-for-report class
+      if (!e.classList.contains('keep-for-report')) {
+        e.remove();
+      }
+      // END WAZUH
+    });
 
   // remove anything that shouldn't be shared
   doc.querySelectorAll('.hide-for-sharing').forEach((e) => e.remove());

--- a/public/components/visual_report/generate_report.ts
+++ b/public/components/visual_report/generate_report.ts
@@ -59,8 +59,10 @@ const removeNonReportElements = (
 ) => {
   // remove buttons
   doc
-    .querySelectorAll("button[class^='euiButton']:not(.visLegend__button)")
+    // WAZUH: Preserve custom button group filters
+    .querySelectorAll("button[class^='euiButton']:not(.visLegend__button):not(.euiButtonGroupButton)")
     .forEach((e) => e.remove());
+    // END WAZUH
 
   // remove anything that shouldn't be shared
   doc.querySelectorAll('.hide-for-sharing').forEach((e) => e.remove());

--- a/public/components/visual_report/generate_report.ts
+++ b/public/components/visual_report/generate_report.ts
@@ -58,11 +58,13 @@ const removeNonReportElements = (
   reportSource: VISUAL_REPORT_TYPE
 ) => {
   // remove buttons
+  // WAZUH: add :not(.euiButtonGroupButton) to preserve custom button group filters
   doc
-    // WAZUH: Preserve custom button group filters
-    .querySelectorAll("button[class^='euiButton']:not(.visLegend__button):not(.euiButtonGroupButton)")
+    .querySelectorAll(
+      "button[class^='euiButton']:not(.visLegend__button):not(.euiButtonGroupButton)"
+    )
     .forEach((e) => e.remove());
-    // END WAZUH
+  // END WAZUH
 
   // remove anything that shouldn't be shared
   doc.querySelectorAll('.hide-for-sharing').forEach((e) => e.remove());

--- a/public/components/visual_report/generate_report.ts
+++ b/public/components/visual_report/generate_report.ts
@@ -59,9 +59,7 @@ const removeNonReportElements = (
 ) => {
   // remove buttons
   doc
-    .querySelectorAll(
-      "button[class^='euiButton']:not(.visLegend__button)"
-    )
+    .querySelectorAll("button[class^='euiButton']:not(.visLegend__button)")
     .forEach((e) => {
       // WAZUH: preserve elements marked with keep-for-report class
       if (!e.classList.contains('keep-for-report')) {


### PR DESCRIPTION
### Description
Fixes an issue where custom button group filters (such as the Under Evaluation filter in the Vulnerabilities Detection dashboard) were not rendered in generated PDF reports.

### Issues Resolved
- **Closes**: https://github.com/wazuh/wazuh-dashboard-reporting/issues/133

### Tests
1. Navigate to Vulnerabilities Detection > Dashboard
2. Select a filter from the custom filter button group (Evaluated or Under Evaluation)
3. Click on Generate report
4. Verify that the report now displays the under evaluation filter correctly

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [X] Updated CHANGELOG.md
- [X] Commits are signed per the DCO using --signoff