### PR TITLE
Fix tag references on bump when --tag is provided

### DIFF
--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -458,47 +458,13 @@ update_package_json() {
   fi
 }
 
-update_manual_build_workflow() {
-  local WORKFLOW_FILE="$WAZUH_DASHBOARD_REPORTING_WORKFLOW_FILE"
-  if [ -f "$WORKFLOW_FILE" ]; then
-    log "Processing $WORKFLOW_FILE"
-    local modified=false
-    # Update version in manual build workflow
-    # on:
-    #   workflow_call:
-    #     inputs:
-    #       reference:
-    #         required: true
-    #         type: string
-    #         description: Source code reference (branch, tag or commit SHA)
-    #         default: 4.13.0
-    # Update the default value for the reference input
-    if [[ "$CURRENT_VERSION" != "$VERSION" ]]; then
-      log "Attempting to update default reference to $VERSION in $WORKFLOW_FILE"
-      # Note: This sed command assumes a specific formatting and might be fragile.
-      # It looks for the line starting with "default:" and replaces the version value
-      # Ensure to escape special characters if necessary
-      sed_inplace "s/^\\([[:space:]]*default:[[:space:]]*\\)$CURRENT_VERSION/\\1$VERSION/" "$WORKFLOW_FILE"
-      modified=true
-    fi
-
-    if [[ $modified == true ]]; then
-      log "Successfully updated $WORKFLOW_FILE with new default reference: $VERSION"
-    fi
-  else
-    log "WARNING: $WORKFLOW_FILE not found. Skipping update."
-  fi
-  log "Updating $WAZUH_DASHBOARD_REPORTING_WORKFLOW_FILE workflow..."
-
-}
-
 update_branch_reference_defaults() {
   if [[ "$SKIP_URLS" == "yes" ]]; then
     log "skip_urls is yes (--set-as-main): leaving workflow branch defaults unchanged"
     return 0
   fi
 
-  local bump_string="$VERSION"
+  local bump_string="$GIT_REF_REPLACEMENT"
   local files=(
     "${REPO_PATH}/.github/workflows/5_builderpackage_reporting_plugin.yml"
     "${REPO_PATH}/.github/workflows/5_builderprecompiled_base-dev-environment.yml"
@@ -568,6 +534,20 @@ update_imposter_config() {
   }
 }
 
+get_git_ref_replacement(){
+  local replacement
+  if [ "$TAG" = true ]; then
+    replacement="v${VERSION}"
+    if [ -n "$STAGE" ]; then
+      replacement+="-${STAGE}"
+    fi
+  else
+    replacement="${VERSION}"
+  fi
+
+  GIT_REF_REPLACEMENT="$replacement"
+}
+
 # --- Main Execution ---
 main() {
   # Initialize log file
@@ -603,13 +583,14 @@ main() {
     log "Freeze mode enabled: version values and branch references will be updated."
   fi
 
+  get_git_ref_replacement
+
   # Start file modifications
   log "Starting file modifications..."
 
   update_root_version_json
   update_package_json
   update_changelog
-  update_manual_build_workflow
   update_branch_reference_defaults
 
   # Update docker/imposter/wazuh-config.yml


### PR DESCRIPTION
### Description

This pull request fixes the git references in some files on bump when --tag is provided.

### Issues Resolved

https://github.com/wazuh/wazuh-dashboard/issues/1295

### Evidences

```
diff --git a/.github/workflows/5_builderpackage_reporting_plugin.yml b/.github/workflows/5_builderpackage_reporting_plugin.yml
index 6e04341..0f6805e 100644
--- a/.github/workflows/5_builderpackage_reporting_plugin.yml
+++ b/.github/workflows/5_builderpackage_reporting_plugin.yml
@@ -22,13 +22,13 @@ on:
         required: true
         type: string
         description: Git reference (branch, tag, or commit SHA) to build from.
-        default: main
+        default: v5.0.0-beta3
   workflow_dispatch:
     inputs:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0-beta3
         description: Git reference (branch, tag, or commit SHA) to build from.
 
 jobs:
diff --git a/.github/workflows/5_builderprecompiled_base-dev-environment.yml b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
index 26b9325..c3f1f3e 100644
--- a/.github/workflows/5_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
@@ -20,7 +20,7 @@ on:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0-beta3
         description: Git reference (branch, tag, or commit SHA) to build from.
       command:
         required: true
diff --git a/.github/workflows/6_builderpackage_reporting_plugin.yml b/.github/workflows/6_builderpackage_reporting_plugin.yml
index 3dc6d54..cf022b1 100644
--- a/.github/workflows/6_builderpackage_reporting_plugin.yml
+++ b/.github/workflows/6_builderpackage_reporting_plugin.yml
@@ -22,13 +22,13 @@ on:
         required: true
         type: string
         description: Git reference (branch, tag, or commit SHA) to build from.
-        default: main
+        default: v5.0.0-beta3
   workflow_dispatch:
     inputs:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0-beta3
         description: Git reference (branch, tag, or commit SHA) to build from.
 
 jobs:
diff --git a/.github/workflows/6_builderprecompiled_base-dev-environment.yml b/.github/workflows/6_builderprecompiled_base-dev-environment.yml
index 26b9325..c3f1f3e 100644
--- a/.github/workflows/6_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/6_builderprecompiled_base-dev-environment.yml
@@ -20,7 +20,7 @@ on:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0-beta3
         description: Git reference (branch, tag, or commit SHA) to build from.
       command:
         required: true
diff --git a/CHANGELOG.md b/CHANGELOG.md
index 6c95f19..372c719 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
-## Wazuh dashboard v5.0.0 - OpenSearch Dashboards 3.6.0 - Revision 02
+## Wazuh dashboard v5.0.0 - OpenSearch Dashboards 3.6.0 - Revision 03
 
 ### Added
 
diff --git a/VERSION.json b/VERSION.json
index 0533024..a57868a 100644
--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
   "version": "5.0.0",
-  "stage": "beta2"
+  "stage": "beta3"
 }
diff --git a/package.json b/package.json
index 669d319..4044f88 100644
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "wazuh": {
     "version": "5.0.0",
-    "revision": "02"
+    "revision": "03"
   },
   "scripts": {
     "osd": "node ../../scripts/osd"
```

### Test

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

## Other

| Test | Result |
| --- |  --- |
| Run `./repository_bumper.sh --tag --stage beta3`, then check the references to `main` were changed to the tag `git --no-pager diff` | :black_circle: |

**Details**
<details>
<summary>:black_circle: Run `./repository_bumper.sh --tag --stage beta3`, then check the references to `main` were changed to the tag `git --no-pager diff`</summary>

</details>

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

