### PR TITLE
Add bump-issue-link parameter to bumper workflow

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -18,12 +18,16 @@ on:
         description: 'Issue link in format https://github.com/wazuh/<REPO>/issues/<ISSUE-NUMBER>'
         required: true
         type: string
+      bump-issue-link:
+        description: 'Issue link used in the original bump (required for revert if different from issue-link)'
+        required: false
+        type: string
       id:
         description: 'Optional identifier for the run'
         required: false
         type: string
       set_as_main:
-        description: "Enable main branch mode: bump version values only, keep branch references pointing to main"
+        description: 'Enable main branch mode: bump version values only, keep branch references pointing to main'
         required: false
         type: boolean
         default: false
@@ -146,8 +150,17 @@ jobs:
         id: revert_step
         if: inputs.revert == true
         run: |
+          # 1. Get the current issue number from the original bump (for the new revert branch/PR)
           ISSUE_NUMBER=$(echo "${{ inputs.issue-link }}" | awk -F'/' '{print $NF}')
 
+          # 2. Get the issue number from the original bump (if provided; otherwise, defaults to the current one)
+          if [ -n "${{ inputs.bump-issue-link }}" ]; then
+            BUMP_ISSUE_NUMBER=$(echo "${{ inputs.bump-issue-link }}" | awk -F'/' '{print $NF}')
+          else
+            BUMP_ISSUE_NUMBER=$ISSUE_NUMBER
+          fi
+
+          # 3. Search for the original bump branch using the obtained BUMP ISSUE number
           BUMP_BRANCH="enhancement/wqa${ISSUE_NUMBER}-bump-${{ github.ref_name }}"
 
           PR_NUMBER=$(gh pr list --head "$BUMP_BRANCH" --base "${{ github.ref_name }}" --state merged --json number --jq '.[0].number')
@@ -164,6 +177,7 @@ jobs:
 
           git revert -m 1 $MERGE_COMMIT --no-commit
 
+          # Remove the files to prevent them from being included in the revert commit
           git checkout HEAD -- VERSION.json 2>/dev/null || true
           git checkout HEAD -- CHANGELOG.md 2>/dev/null || true
           git checkout HEAD -- package.json 2>/dev/null || true

--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -161,7 +161,7 @@ jobs:
           fi
 
           # 3. Search for the original bump branch using the obtained BUMP ISSUE number
-          BUMP_BRANCH="enhancement/wqa${ISSUE_NUMBER}-bump-${{ github.ref_name }}"
+          BUMP_BRANCH="enhancement/wqa${BUMP_ISSUE_NUMBER}-bump-${{ github.ref_name }}"
 
           PR_NUMBER=$(gh pr list --head "$BUMP_BRANCH" --base "${{ github.ref_name }}" --state merged --json number --jq '.[0].number')
 


### PR DESCRIPTION
### Description
This PR adds a new parameter to the bump workflow. This parameter supports scenarios where the tracking issue for the revert is different from the original bump issue

### Issues Resolved
#172 

### Evidence

https://github.com/Adman23/wazuh-dashboard-reporting

<details><summary>Bump main</summary>

<img width="290" height="588" alt="image" src="https://github.com/user-attachments/assets/22e09376-5a2a-46b1-bff0-9bf33f2ae118" />

<img width="1898" height="499" alt="image" src="https://github.com/user-attachments/assets/6fe7cde2-7f82-4ed0-b6e2-e2645331acff" />

https://github.com/Adman23/wazuh-dashboard-reporting/actions/runs/27609817828/job/81631062803

</details> 


<details><summary>Revert bump main with new parameter</summary>

<img width="285" height="581" alt="image" src="https://github.com/user-attachments/assets/754af28d-8a55-428a-a280-1e2674bc4e91" />

<img width="1910" height="570" alt="image" src="https://github.com/user-attachments/assets/a0c04ba7-d884-4319-8068-74d4de4e7934" />

https://github.com/Adman23/wazuh-dashboard-reporting/actions/runs/27609947294/job/81631510994

</details> 

### Tests

- Check the last two repository bumper actions to verify the parameter was used correctly and the bump and revert worked.
- Code review.
- Repeat the process on your own fork of the repo (optional).

### Check List
- [x] Commits are signed per the DCO using --signoff