### PR TITLE
Report skipped bumps in the repository bumper workflow

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -166,10 +166,14 @@ jobs:
           PR_NUMBER=$(gh pr list --head "$BUMP_BRANCH" --base "${{ github.ref_name }}" --state merged --json number --jq '.[0].number')
 
           if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
-            echo "Error: The original PR for the bump was not found"
+            echo "The original PR for the bump was not found"
             echo "Searching merged PR from: $BUMP_BRANCH to ${{ github.ref_name }}"
-            exit 1
+            echo "pr_found=false" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
+
+          echo "pr_found=true" >> $GITHUB_OUTPUT
 
           echo "Original PR found: #$PR_NUMBER"
 
@@ -189,6 +193,17 @@ jobs:
             git commit -m "feat: revert ${{ github.ref_name }} references"
             echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
+
+      - name: 'Result: original bump pull request not found'
+        if: inputs.revert == true && steps.revert_step.outputs.pr_found == 'false'
+        run: echo "There is no original bump pull request to revert, nothing to do."
+
+      - name: 'Result: no changes to commit'
+        if: >-
+          (inputs.revert != true && steps.check_changes.outputs.has_changes == 'false') ||
+          (inputs.revert == true && steps.revert_step.outputs.pr_found == 'true' &&
+          steps.revert_step.outputs.has_changes == 'false')
+        run: echo "The bump produced no changes, no pull request was created."
 
       - name: Push changes
         if: (inputs.revert != true && steps.check_changes.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')


### PR DESCRIPTION
## Description

The release orchestration in `wazuh-qa-automation` now tells apart a repository bump that **failed** from one that **had nothing to do**, so a release is no longer blocked by a repository where the bump was a no-op ([wazuh-qa-automation#8027](https://github.com/wazuh/wazuh-qa-automation/issues/8027)). Today `.github/workflows/5_bumper_repository.yml` ends with the `failure` conclusion in two harmless situations, giving the orchestrator no way to tell them apart from a real failure:

- On a revert run, when the original bump pull request doesn't exist because that bump introduced no changes.
- On a bump run, when the bump script produces no changes.

Closes #206

## Proposed Changes

- `Revert references (Revert)`: when no merged original bump PR is found, stop reporting it as an error — emit `pr_found=false` / `has_changes=false` outputs and exit `0` instead of `exit 1`.
- Added two result-reporting steps, matched by name by the orchestrator (kept exactly as specified in the issue):
  - `Result: original bump pull request not found` — runs when the revert can't find an original bump PR.
  - `Result: no changes to commit` — runs when the bump produced no changes (bump path) or the revert found the PR but had nothing to revert.
- `Commit changes (Bump)` was already guarded by the existing `Check for changes` step, and `Push changes` / `Create pull request` / `Merge pull request` were already conditioned on the same `has_changes` outputs, so no changes were needed there — the run now completes as `success` in both no-op cases while still skipping those steps.

### Results and Evidence

<!-- Attach the links of the four validation runs required by the issue (revert with no original PR, bump with no changes, normal bump, normal revert) once they've been executed on the release branch. -->

### Artifacts Affected

- `.github/workflows/5_bumper_repository.yml` (CI workflow only — no plugin runtime artifacts affected).

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None (GitHub Actions workflow change — validated via the four live workflow runs described in the issue's Validations section, see Results and Evidence).

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
